### PR TITLE
Merged netflix-max-bitrate functionality into Netflix 1080p

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -7,13 +7,13 @@ script_urls = [
 
 urls = [
     'msl_client.js',
-	'netflix_max_bitrate.js'
+    'netflix_max_bitrate.js'
 ]
 
 // very messy workaround for accessing chrome storage outside of background / content scripts
 chrome.storage.sync.get(['use6Channels', 'setMaxBitrate'], function(items) {
     var use6Channels = items.use6Channels;
-	var setMaxBitrate = items.setMaxBitrate;
+    var setMaxBitrate = items.setMaxBitrate;
     var mainScript = document.createElement('script');
     mainScript.type = 'application/javascript';
     mainScript.text = 'var use6Channels = ' + use6Channels + ';' + '\n' 

--- a/content_script.js
+++ b/content_script.js
@@ -6,15 +6,18 @@ script_urls = [
 ]
 
 urls = [
-    'msl_client.js'
+    'msl_client.js',
+	'netflix_max_bitrate.js'
 ]
 
 // very messy workaround for accessing chrome storage outside of background / content scripts
-chrome.storage.sync.get(['use6Channels'], function(items) {
+chrome.storage.sync.get(['use6Channels', 'setMaxBitrate'], function(items) {
     var use6Channels = items.use6Channels;
+	var setMaxBitrate = items.setMaxBitrate;
     var mainScript = document.createElement('script');
     mainScript.type = 'application/javascript';
-    mainScript.text = 'var use6Channels = ' + use6Channels;
+    mainScript.text = 'var use6Channels = ' + use6Channels + ';' + '\n' 
+	                + 'var setMaxBitrate = ' + setMaxBitrate + ';';
     document.documentElement.appendChild(mainScript);
 });
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Netflix 1080p",
   "description": "Forces 1080p and 5.1 playback for Netflix.",
-  "version": "1.18",
+  "version": "1.2",
   "author": "truedread",
   "browser_action": {
     "default_icon": "img/icon128.png"

--- a/manifest.json
+++ b/manifest.json
@@ -31,7 +31,7 @@
   },
   "web_accessible_resources": [
     "msl_client.js",
-	"netflix_max_bitrate.js",
+    "netflix_max_bitrate.js",
     "cadmium-playercore-6.0015.328.011-1080p.js"
   ],
   "permissions": [

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Netflix 1080p",
   "description": "Forces 1080p and 5.1 playback for Netflix.",
-  "version": "1.2",
+  "version": "1.18",
   "author": "truedread",
   "browser_action": {
     "default_icon": "img/icon128.png"

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Netflix 1080p",
   "description": "Forces 1080p and 5.1 playback for Netflix.",
-  "version": "1.18",
+  "version": "1.2",
   "author": "truedread",
   "browser_action": {
     "default_icon": "img/icon128.png"
@@ -31,6 +31,7 @@
   },
   "web_accessible_resources": [
     "msl_client.js",
+	"netflix_max_bitrate.js",
     "cadmium-playercore-6.0015.328.011-1080p.js"
   ],
   "permissions": [

--- a/netflix_max_bitrate.js
+++ b/netflix_max_bitrate.js
@@ -1,5 +1,3 @@
-console.log("In netflix_max_bitrate");
-
 let getElementByXPath = function (xpath) {
   return document.evaluate(
     xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null
@@ -47,11 +45,14 @@ const WATCH_REGEXP = /netflix.com\/watch\/.*/;
 
 let oldLocation;
 
-setInterval(function () {
-  let newLocation = window.location.toString();
+if(setMaxBitrate) {
+  console.log("netflix_max_bitrate.js enabled");
+  setInterval(function () {
+    let newLocation = window.location.toString();
 
-  if (newLocation !== oldLocation) {
-    oldLocation = newLocation;
-    WATCH_REGEXP.test(newLocation) && run();
-  }
-}, 500);
+    if (newLocation !== oldLocation) {
+      oldLocation = newLocation;
+      WATCH_REGEXP.test(newLocation) && run();
+    }
+  }, 500);
+}

--- a/netflix_max_bitrate.js
+++ b/netflix_max_bitrate.js
@@ -1,0 +1,57 @@
+console.log("In netflix_max_bitrate");
+
+let getElementByXPath = function (xpath) {
+  return document.evaluate(
+    xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null
+  ).singleNodeValue;
+};
+
+let fn = function () {
+  window.dispatchEvent(new KeyboardEvent('keydown', {
+    keyCode: 83,
+    ctrlKey: true,
+    altKey: true,
+    shiftKey: true,
+  }));
+
+  const VIDEO_SELECT = getElementByXPath("//div[text()='Video Bitrate']");
+  const AUDIO_SELECT = getElementByXPath("//div[text()='Audio Bitrate']");
+  const BUTTON = getElementByXPath("//button[text()='Override']");
+
+  if (!(VIDEO_SELECT && AUDIO_SELECT && BUTTON)){
+    return false;
+  }
+
+  [VIDEO_SELECT, AUDIO_SELECT].forEach(function (el) {
+    let parent = el.parentElement;
+
+    let options = parent.querySelectorAll('select > option');
+
+    for (var i = 0; i < options.length - 1; i++) {
+      options[i].removeAttribute('selected');
+    }
+
+    options[options.length - 1].setAttribute('selected', 'selected');
+  });
+
+  BUTTON.click();
+
+  return true;
+};
+
+let run = function () {
+  fn() || setTimeout(run, 100);
+};
+
+const WATCH_REGEXP = /netflix.com\/watch\/.*/;
+
+let oldLocation;
+
+setInterval(function () {
+  let newLocation = window.location.toString();
+
+  if (newLocation !== oldLocation) {
+    oldLocation = newLocation;
+    WATCH_REGEXP.test(newLocation) && run();
+  }
+}, 500);

--- a/pages/options.html
+++ b/pages/options.html
@@ -8,6 +8,8 @@
 <body>
     <label>
         <input type="checkbox" id="5.1">Use 5.1 audio when available</input>
+		<br>
+		<input type="checkbox" id="setMaxBitrate">Automatically select best bitrate available</input>
     </label>
 
     <div id="status"></div>

--- a/pages/options.html
+++ b/pages/options.html
@@ -8,8 +8,8 @@
 <body>
     <label>
         <input type="checkbox" id="5.1">Use 5.1 audio when available</input>
-		<br>
-		<input type="checkbox" id="setMaxBitrate">Automatically select best bitrate available</input>
+        <br>
+        <input type="checkbox" id="setMaxBitrate">Automatically select best bitrate available</input>
     </label>
 
     <div id="status"></div>

--- a/pages/options.js
+++ b/pages/options.js
@@ -1,7 +1,9 @@
 function save_options() {
     var use6Channels = document.getElementById('5.1').checked;
+    var setMaxBitrate = document.getElementById('setMaxBitrate').checked;
     chrome.storage.sync.set({
-        use6Channels: use6Channels
+        use6Channels: use6Channels,
+        setMaxBitrate: setMaxBitrate
     }, function() {
         var status = document.getElementById('status');
         status.textContent = 'Options saved.';
@@ -13,9 +15,11 @@ function save_options() {
 
 function restore_options() {
     chrome.storage.sync.get({
-        use6Channels: false
+        use6Channels: false,
+        setMaxBitrate: false
     }, function(items) {
         document.getElementById('5.1').checked = items.use6Channels;
+        document.getElementById('setMaxBitrate').checked = items.setMaxBitrate;
     });
 }
 


### PR DESCRIPTION
Combined the functionality of Firefox plugin [netflix-max-bitrate](https://github.com/ItsNickBarry/netflix-max-bitrate) into this project.

This solves https://github.com/truedread/netflix-1080p/issues/70 and https://github.com/truedread/netflix-1080p/issues/51

My motivation for doing this was that netflix-1080p unlocks excellent bitrates for Chrome in 1080p, however, Netflix arbitrarily decides to drop the bitrate in the middle of a film for me if I don't manually set the bitrate each time in the CTRL+ALT+Shift+S menu. 

The netflix-max-bitrate functionality automatically selects this best bitrate without me having to do it manually every time I change episodes or film.

I also implemented a toggle for the feature, which is off by default.
![chrome_2019-08-26_00-15-39](https://user-images.githubusercontent.com/7999692/63657207-b0fe7a00-c796-11e9-8f59-aae4279ff75c.png)
