### PR TITLE
Fix label -> checkbox usability issue in options page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Netflix 1080p",
   "description": "Forces 1080p and 5.1 playback for Netflix.",
-  "version": "1.22",
+  "version": "1.23",
   "author": "truedread",
   "browser_action": {
     "default_icon": "img/icon128.png"

--- a/pages/options.html
+++ b/pages/options.html
@@ -7,11 +7,18 @@
 
 <body>
     <label>
-        <input type="checkbox" id="5.1">Use 5.1 audio when available</input>
-        <br>
-        <input type="checkbox" id="setMaxBitrate">Automatically select best bitrate available</input>
-        <br>
-        <input type="checkbox" id="useVP9">Use VP9 instead of H.264</input>
+        <input type="checkbox" id="5.1" />
+        Use 5.1 audio when available
+    </label>
+    <br>
+    <label>
+        <input type="checkbox" id="setMaxBitrate" />
+        Automatically select best bitrate available
+    </label>
+    <br>
+    <label>
+        <input type="checkbox" id="useVP9" />
+        Use VP9 instead of H.264
     </label>
 
     <div id="status"></div>


### PR DESCRIPTION
Previously, all the text for all options was incorrectly marked as the label of the first checkbox. As a result, clicking on any of the text would *confusingly* toggle the 5.1 audio option. This commit assigns each label to an individual checkbox -- each checkbox can be toggled by clicking on its respective option.